### PR TITLE
Fixed a small typo for the element "LocalInstrument"

### DIFF
--- a/lib/SepaPaymentInfo.php
+++ b/lib/SepaPaymentInfo.php
@@ -130,7 +130,7 @@ class SepaPaymentInfo extends SepaFileBlock
 	public function setLocalInstrumentCode($code)
 	{
 		$code = strtoupper($code);
-		if (!in_array($code, array('CORE', 'B2B'))) {
+		if (!in_array($code, array('CORE', 'B2B','COR1'))) {
 			throw new Exception("Invalid Local Instrument Code: $code");
 		}
 		$this->localInstrumentCode = $code;


### PR DESCRIPTION
The element "LocalInstrument" (LclInstrm) was used as LclInstr, which is incorrect according to pain.001.001.03.xsd
