### PR TITLE
Accept COR1 local instrument code for direct debits

### DIFF
--- a/lib/Digitick/Sepa/PaymentInformation.php
+++ b/lib/Digitick/Sepa/PaymentInformation.php
@@ -178,7 +178,7 @@ class PaymentInformation
      */
     public function setLocalInstrumentCode($localInstrumentCode) {
         $localInstrumentCode = strtoupper($localInstrumentCode);
-        if (!in_array($localInstrumentCode, array('B2B', 'CORE'))) {
+        if (!in_array($localInstrumentCode, array('B2B', 'CORE', 'COR1'))) {
             throw new InvalidArgumentException("Invalid Local Instrument Code: $localInstrumentCode");
         }
         $this->localInstrumentCode = $localInstrumentCode;

--- a/lib/Digitick/Sepa/TransferFile/Facade/CustomerDirectDebitFacade.php
+++ b/lib/Digitick/Sepa/TransferFile/Facade/CustomerDirectDebitFacade.php
@@ -55,6 +55,9 @@ class CustomerDirectDebitFacade extends BaseCustomerTransferFileFacade
         );
         $payment->setSequenceType($paymentInformation['seqType']);
         $payment->setCreditorId($paymentInformation['creditorId']);
+        if (isset($paymentInformation['localInstrumentCode'])) {
+            $payment->setLocalInstrumentCode($paymentInformation['localInstrumentCode']);
+        }
         if(isset($paymentInformation['dueDate'])) {
             if($paymentInformation['dueDate'] instanceof \DateTime) {
                 $payment->setDueDate($paymentInformation['dueDate']);


### PR DESCRIPTION
Accept COR1 local instrument code for direct debits with shorter presentation cycle.
See http://www.sepaforcorporates.com/sepa-direct-debits/quick-guide-to-cor1-sepa-direct-debits/
