### PR TITLE
Fixed DOMDocument::createElement(): unterminated entity reference

### DIFF
--- a/lib/Digitick/Sepa/DomBuilder/BaseDomBuilder.php
+++ b/lib/Digitick/Sepa/DomBuilder/BaseDomBuilder.php
@@ -59,7 +59,9 @@ abstract class BaseDomBuilder implements DomBuilderInterface
      */
     protected function createElement($name, $value = null) {
         if($value){
-            return $this->doc->createElement($name, $value);
+            $elm = $this->doc->createElement($name);
+            $elm->appendChild($this->doc->createTextNode($value));
+            return $elm;
         } else {
             return $this->doc->createElement($name);
         }


### PR DESCRIPTION
createElement($name, $value) does not encode the value, replaced with a TextNode element.
