### PR TITLE
fixed double quoting of Nm Tag / htmlentities deleted.

### DIFF
--- a/lib/Digitick/Sepa/DomBuilder/CustomerCreditTransferDomBuilder.php
+++ b/lib/Digitick/Sepa/DomBuilder/CustomerCreditTransferDomBuilder.php
@@ -86,7 +86,7 @@ class CustomerCreditTransferDomBuilder extends BaseDomBuilder
 
         $this->currentPayment->appendChild($this->createElement('ReqdExctnDt', $paymentInformation->getDueDate()));
         $debtor = $this->createElement('Dbtr');
-        $debtor->appendChild($this->createElement('Nm', htmlentities($paymentInformation->getOriginName())));
+        $debtor->appendChild($this->createElement('Nm', $paymentInformation->getOriginName()));
         $this->currentPayment->appendChild($debtor);
 
         $debtorAccount = $this->createElement('DbtrAcct');
@@ -143,7 +143,7 @@ class CustomerCreditTransferDomBuilder extends BaseDomBuilder
 
         // Creditor 2.79
         $creditor = $this->createElement('Cdtr');
-        $creditor->appendChild($this->createElement('Nm', htmlentities($transactionInformation->getCreditorName())));
+        $creditor->appendChild($this->createElement('Nm', $transactionInformation->getCreditorName()));
         $CdtTrfTxInf->appendChild($creditor);
 
         // CreditorAccount 2.80


### PR DESCRIPTION
With htmlentities in Nm Tag was a problem with "&" because was a double quoting with the result "&amp;amp" that is not correct.. Result have to be "&amp;". With deleting htmlentities this problem is resolved.
