### PR TITLE
adjustable format for creation date time

### DIFF
--- a/lib/Digitick/Sepa/DomBuilder/BaseDomBuilder.php
+++ b/lib/Digitick/Sepa/DomBuilder/BaseDomBuilder.php
@@ -109,7 +109,7 @@ abstract class BaseDomBuilder implements DomBuilderInterface
         $groupHeaderTag->appendChild($messageId);
         $creationDateTime = $this->createElement(
             'CreDtTm',
-            $groupHeader->getCreationDateTime()->format('Y-m-d\TH:i:s\Z')
+            $groupHeader->getCreationDateTime()->format($groupHeader->getCreationDateTimeFormat())
         );
         $groupHeaderTag->appendChild($creationDateTime);
         $groupHeaderTag->appendChild($this->createElement('NbOfTxs', $groupHeader->getNumberOfTransactions()));

--- a/lib/Digitick/Sepa/GroupHeader.php
+++ b/lib/Digitick/Sepa/GroupHeader.php
@@ -67,6 +67,11 @@ class GroupHeader
     protected $creationDateTime;
 
     /**
+     * @var string
+     */
+    protected $creationDateTimeFormat = 'Y-m-d\TH:i:s\Z';
+
+    /**
      * Should the bank book multiple transaction as a batch
      *
      * @var int
@@ -211,4 +216,19 @@ class GroupHeader
         return $this->creationDateTime;
     }
 
+    /**
+     * @param string $creationDateTimeFormat
+     */
+    public function setCreationDateTimeFormat($creationDateTimeFormat)
+    {
+        $this->creationDateTimeFormat = $creationDateTimeFormat;
+    }
+
+    /**
+     * @return string
+     */
+    public function getCreationDateTimeFormat()
+    {
+        return $this->creationDateTimeFormat;
+    }
 }


### PR DESCRIPTION
A local time format with utc offset ("'Y-m-d\TH:i:s.000P")
is required by a german bank (sparkasse-koelnbonn.de).
