### PR TITLE
Update BaseTransferInformation.php

### DIFF
--- a/lib/Digitick/Sepa/TransferInformation/BaseTransferInformation.php
+++ b/lib/Digitick/Sepa/TransferInformation/BaseTransferInformation.php
@@ -90,6 +90,8 @@ class BaseTransferInformation implements TransferInformationInterface
             }
             bcscale(2);
             $amount = (integer)bcmul($amount, 100);
+        } else {
+            $amount = (integer)$amount * 100;
         }
         $this->transferAmount = $amount;
         $this->iban = $iban;


### PR DESCRIPTION
Necessary else clause, because otherwise it will not multiply non-floats with 100,which leads as a result to wrong transferAmount values. The $amount of 100 would be saved as transferAmount = 100, which generates a wrong value of 10.00 EUR when converted back to SEPA-Amount in CustomDirectDebitTransferDomBuilder->inToCurrency in visitTransferInformation().
