### PR TITLE
Moved the BtchBookg node to the correct position and introduced the missing Issr node

### DIFF
--- a/lib/Digitick/Sepa/DomBuilder/BaseDomBuilder.php
+++ b/lib/Digitick/Sepa/DomBuilder/BaseDomBuilder.php
@@ -116,9 +116,7 @@ abstract class BaseDomBuilder implements DomBuilderInterface
         $groupHeaderTag->appendChild(
             $this->createElement('CtrlSum', $this->intToCurrency($groupHeader->getControlSumCents()))
         );
-        if($groupHeader->getBatchBooking() !== null) {
-            $groupHeaderTag->appendChild($this->createElement('BtchBookg', $groupHeader->getBatchBooking()));
-        }
+
         $initiatingParty = $this->createElement('InitgPty');
         $initiatingPartyName = $this->createElement('Nm', $groupHeader->getInitiatingPartyName());
         $initiatingParty->appendChild($initiatingPartyName);

--- a/lib/Digitick/Sepa/DomBuilder/CustomerCreditTransferDomBuilder.php
+++ b/lib/Digitick/Sepa/DomBuilder/CustomerCreditTransferDomBuilder.php
@@ -59,6 +59,11 @@ class CustomerCreditTransferDomBuilder extends BaseDomBuilder
         $this->currentPayment = $this->createElement('PmtInf');
         $this->currentPayment->appendChild($this->createElement('PmtInfId', $paymentInformation->getId()));
         $this->currentPayment->appendChild($this->createElement('PmtMtd', $paymentInformation->getPaymentMethod()));
+
+        if($paymentInformation->getBatchBooking() !== null) {
+            $this->currentPayment->appendChild($this->createElement('BtchBookg', $paymentInformation->getBatchBooking()));
+        }
+
         $this->currentPayment->appendChild(
             $this->createElement('NbOfTxs', $paymentInformation->getNumberOfTransactions())
         );
@@ -178,6 +183,11 @@ class CustomerCreditTransferDomBuilder extends BaseDomBuilder
             $orgId = $this->createElement('OrgId');
             $othr  = $this->createElement('Othr');
             $othr->appendChild($this->createElement('Id', $groupHeader->getInitiatingPartyId()));
+
+            if ($groupHeader->getIssuer()) {
+                $othr->appendChild($this->createElement('Issr', $groupHeader->getIssuer()));
+            }
+
             $orgId->appendChild($othr);
             $newId->appendChild($orgId);
 

--- a/lib/Digitick/Sepa/GroupHeader.php
+++ b/lib/Digitick/Sepa/GroupHeader.php
@@ -46,6 +46,13 @@ class GroupHeader
      */
     protected $initiatingPartyId;
 
+	/**
+	 * The Issuer.
+	 *
+	 * @var string
+	 */
+	protected $issuer;
+
     /**
      * @var int
      */
@@ -65,13 +72,6 @@ class GroupHeader
      * @var \DateTime
      */
     protected $creationDateTime;
-
-    /**
-     * Should the bank book multiple transaction as a batch
-     *
-     * @var int
-     */
-    protected $batchBooking = null;
 
     /**
      * @param $messageIdentification
@@ -123,6 +123,22 @@ class GroupHeader
         return $this->initiatingPartyId;
     }
 
+	/**
+	 * @return string
+	 */
+	public function getIssuer()
+	{
+		return $this->issuer;
+	}
+
+	/**
+	 * @param string $issuer
+	 */
+	public function setIssuer($issuer)
+	{
+		$this->issuer = $issuer;
+	}
+
     /**
      * @param string $initiatingPartyName
      */
@@ -153,22 +169,6 @@ class GroupHeader
     public function getIsTest()
     {
         return $this->isTest;
-    }
-    
-    /**
-     * @param boolean $batchBooking
-     */
-    public function setBatchBooking($batchBooking)
-    {
-        $this->batchBooking = $batchBooking;
-    }
-
-    /**
-     * @return int|null
-     */
-    public function getBatchBooking()
-    {
-        return $this->batchBooking;
     }
 
     /**

--- a/lib/Digitick/Sepa/PaymentInformation.php
+++ b/lib/Digitick/Sepa/PaymentInformation.php
@@ -129,6 +129,13 @@ class PaymentInformation
     protected $sequenceType;
 
     /**
+     * Should the bank book multiple transaction as a batch
+     *
+     * @var int
+     */
+    protected $batchBooking = null;
+
+    /**
      * @param string $id
      * @param string $originAccountIBAN This is your IBAN
      * @param string $originAgentBIC This is your BIC
@@ -408,4 +415,19 @@ class PaymentInformation
         return $this->sequenceType;
     }
 
+    /**
+     * @param boolean $batchBooking
+     */
+    public function setBatchBooking($batchBooking)
+    {
+        $this->batchBooking = $batchBooking;
+    }
+
+    /**
+     * @return int|null
+     */
+    public function getBatchBooking()
+    {
+        return $this->batchBooking;
+    }
 }


### PR DESCRIPTION
According to the pain format .xsd's, BtchBookg should always reside in the PaymentInstructionInformation node.

In the past there was a 001.001.02 format that required the BtchBookg to reside in the Header, this is no longer the case in the newer formats.

This library claims support for 'pain.001.002.03', 'pain.001.001.03', 'pain.008.002.02', 'pain.008.001.02' which all require the BtchBookg to be in the PaymentInstructionInformation.

The other implemented child of the BaseDomBuilder, CustomerDirectDebitTransferDomBuilder never used the BatchBooking so it should continue to work.

Finally, the supported formats describe BtchBookg as 'minOccurs="0"', so omission of the field should not break functionality.

http://docs.oracle.com/cd/E16582_01/doc.91/e15104/fields_sepa_pay_file_appx.htm
https://www.ing.be/SiteCollectionDocuments/XMLGuide_ECT_EN.pdf
